### PR TITLE
feat: do not unlink when expiration happens

### DIFF
--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -651,10 +651,6 @@ void O2::onRefreshFinished() {
 void O2::onRefreshError(QNetworkReply::NetworkError error) {
     QNetworkReply *refreshReply = qobject_cast<QNetworkReply *>(sender());
     int code = refreshReply ? refreshReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() : 0;
-    if (code >= 400 && code <= 499)
-    {
-        unlink();
-    }
     log( QStringLiteral("O2::onRefreshError: %1 (code %2)").arg( error ).arg( code ), O0BaseAuth::LogLevel::Warning );
     timedReplies_.remove(refreshReply);
     Q_EMIT refreshFinished(error);


### PR DESCRIPTION
- this is to distinguish between the case where it expires while running and where the user just logs out